### PR TITLE
Fixes #5 - add support for image overlay highlights

### DIFF
--- a/lib/src/board_color_scheme.dart
+++ b/lib/src/board_color_scheme.dart
@@ -14,6 +14,7 @@ class BoardColorScheme {
     required this.whiteCoordBackground,
     required this.blackCoordBackground,
     required this.lastMove,
+    required this.lastMoveDestination,
     required this.selected,
     required this.validMoves,
     required this.validPremoves,
@@ -36,11 +37,14 @@ class BoardColorScheme {
   /// facing coordinates included
   final Background blackCoordBackground;
 
-  /// Color of highlighted last move
-  final Color lastMove;
+  /// Color of highlighted last move that piece moved from
+  final HighlightDetails lastMove;
+
+  /// Color of highlighted last move that piece moved to
+  final HighlightDetails lastMoveDestination;
 
   /// Color of highlighted selected square
-  final Color selected;
+  final HighlightDetails selected;
 
   /// Color of squares occupied with valid moves dots
   final Color validMoves;
@@ -66,8 +70,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -90,8 +95,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809bc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809bc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809bc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -114,8 +120,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color.fromRGBO(0, 155, 199, 0.41),
-    selected: Color.fromRGBO(216, 85, 0, 0.3),
+    lastMove: HighlightDetails(solidColor: Color.fromRGBO(0, 155, 199, 0.41)),
+    lastMoveDestination: HighlightDetails(solidColor: Color.fromRGBO(0, 155, 199, 0.41)),
+    selected: HighlightDetails(solidColor: Color.fromRGBO(216, 85, 0, 0.3)),
     validMoves: Color.fromRGBO(0, 0, 0, 0.20),
     validPremoves: Color(0x40203085),
   );
@@ -141,8 +148,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -168,8 +176,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -195,8 +204,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -222,8 +232,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -249,8 +260,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color.fromRGBO(0, 155, 199, 0.41),
-    selected: Color.fromRGBO(216, 85, 0, 0.3),
+    lastMove: HighlightDetails(solidColor: Color.fromRGBO(0, 155, 199, 0.41)),
+    lastMoveDestination: HighlightDetails(solidColor: Color.fromRGBO(0, 155, 199, 0.41)),
+    selected: HighlightDetails(solidColor: Color.fromRGBO(216, 85, 0, 0.3)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -258,7 +270,8 @@ class BoardColorScheme {
   static const grey = BoardColorScheme(
     lightSquare: Color(0xffb8b8b8),
     darkSquare: Color(0xff7d7d7d),
-    lastMove: Color(0x809cc700),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
     background: ImageBackground(
       lightSquare: Color(0xffb8b8b8),
       darkSquare: Color(0xff7d7d7d),
@@ -277,7 +290,7 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    selected: Color(0x6014551e),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -303,8 +316,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(image: AssetImage('lib/boards/horsey.last-move.png', package: 'chessground')),
+    lastMoveDestination: HighlightDetails(image: AssetImage('lib/boards/horsey.move-dest.png', package: 'chessground')),
+    selected: HighlightDetails(image: AssetImage('lib/boards/horsey.selected.png', package: 'chessground')),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -330,8 +344,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -357,8 +372,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -384,8 +400,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -411,8 +428,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color.fromRGBO(0, 155, 199, 0.41),
-    selected: Color.fromRGBO(216, 85, 0, 0.3),
+    lastMove: HighlightDetails(solidColor: Color.fromRGBO(0, 155, 199, 0.41)),
+    lastMoveDestination: HighlightDetails(solidColor: Color.fromRGBO(0, 155, 199, 0.41)),
+    selected: HighlightDetails(solidColor: Color.fromRGBO(216, 85, 0, 0.3)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -438,8 +456,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -465,8 +484,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -492,8 +512,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -519,8 +540,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -546,8 +568,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -573,8 +596,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -600,8 +624,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -627,8 +652,9 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
@@ -654,9 +680,20 @@ class BoardColorScheme {
       coordinates: true,
       orientation: Side.black,
     ),
-    lastMove: Color(0x809cc700),
-    selected: Color(0x6014551e),
+    lastMove: HighlightDetails(solidColor: Color(0x809cc700)),
+    lastMoveDestination: HighlightDetails(solidColor: Color(0x809cc700)),
+    selected: HighlightDetails(solidColor: Color(0x6014551e)),
     validMoves: Color(0x4014551e),
     validPremoves: Color(0x40203085),
   );
+}
+
+class HighlightDetails {
+  const HighlightDetails({
+    this.solidColor,
+    this.image,
+  });
+
+  final Color? solidColor;
+  final AssetImage? image;
 }

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -1,3 +1,4 @@
+import 'package:chessground/chessground.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart';
 import 'package:tuple/tuple.dart';
@@ -93,18 +94,28 @@ class _BoardState extends State<Board> {
               : colorScheme.blackCoordBackground
         else
           colorScheme.background,
-        if (widget.settings.showLastMove && widget.data.lastMove != null)
-          for (final squareId in widget.data.lastMove!.squares)
-            PositionedSquare(
-              key: ValueKey('$squareId-lastMove'),
+        if (widget.settings.showLastMove && widget.data.lastMove?.from != null)
+          PositionedSquare(
+            key: ValueKey('${widget.data.lastMove!.from}-lastMove'),
+            size: widget.squareSize,
+            orientation: widget.data.orientation,
+            squareId: widget.data.lastMove!.from,
+            child: Highlight(
               size: widget.squareSize,
-              orientation: widget.data.orientation,
-              squareId: squareId,
-              child: Highlight(
-                size: widget.squareSize,
-                color: colorScheme.lastMove,
-              ),
+              details: colorScheme.lastMove,
             ),
+          ),
+        if (widget.settings.showLastMove && widget.data.lastMove?.to != null)
+          PositionedSquare(
+            key: ValueKey('${widget.data.lastMove!.to}-lastMove'),
+            size: widget.squareSize,
+            orientation: widget.data.orientation,
+            squareId: widget.data.lastMove!.to,
+            child: Highlight(
+              size: widget.squareSize,
+              details: colorScheme.lastMoveDestination,
+            ),
+          ),
         if (_premove != null)
           for (final squareId in _premove!.squares)
             PositionedSquare(
@@ -114,7 +125,7 @@ class _BoardState extends State<Board> {
               squareId: squareId,
               child: Highlight(
                 size: widget.squareSize,
-                color: colorScheme.validPremoves,
+                details: HighlightDetails(solidColor: colorScheme.validPremoves),
               ),
             ),
         if (selected != null)
@@ -125,7 +136,7 @@ class _BoardState extends State<Board> {
             squareId: selected!,
             child: Highlight(
               size: widget.squareSize,
-              color: colorScheme.selected,
+              details: colorScheme.selected,
             ),
           ),
         for (final dest in moveDests)

--- a/lib/src/widgets/highlight.dart
+++ b/lib/src/widgets/highlight.dart
@@ -1,22 +1,37 @@
+import 'package:chessground/chessground.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 class Highlight extends StatelessWidget {
   const Highlight({
     super.key,
-    required this.color,
+    required this.details,
     required this.size,
   });
 
-  final Color color;
+  final HighlightDetails details;
   final double size;
 
   @override
   Widget build(BuildContext context) {
+
+    if (details.image != null) {
+      return Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          image: DecorationImage(
+            image: details.image!,
+            fit: BoxFit.cover,
+          )
+        ),
+        color: details.solidColor,
+      );
+    }
     return Container(
       width: size,
       height: size,
-      color: color,
+      color: details.solidColor,
     );
   }
 }


### PR DESCRIPTION
The horsey theme uses images for square highlights as oppose to solid colors. This change introduces a new structure called HighlightDetails that allows for a theme to specify if it wishes to highlight using a solid color or an image.

When rendering, if an image is present, it will take precedent over a solid color.

When rendering a move, Horsey also differentiates between the square moved from and the square moved to -- this meant that a new field needed to be added to all themes to support this case.

![Screenshot_20230508_205647](https://user-images.githubusercontent.com/4302925/236911128-c40384db-81b9-4c1b-88ce-cf843f161485.png)
