### PR TITLE
Fix coordinates and board display on devices with RightToLeft Directionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.4
+
+- Fix coordinates and board display on devices with RightToLeft Directionality.
+
 ## 2.6.3
 
 - Improve coordinates display on the board.

--- a/lib/src/widgets/background.dart
+++ b/lib/src/widgets/background.dart
@@ -31,28 +31,32 @@ class SolidColorBackground extends Background {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox.expand(
-      child: Column(
-        children: List.generate(
-          8,
-          (rank) => Expanded(
-            child: Row(
-              children: List.generate(
-                8,
-                (file) => Expanded(
-                  child: Container(
-                    width: double.infinity,
-                    height: double.infinity,
-                    color: (rank + file).isEven ? lightSquare : darkSquare,
-                    child: coordinates && (file == 7 || rank == 7)
-                        ? _Coordinate(
-                            rank: rank,
-                            file: file,
-                            orientation: orientation,
-                            color:
-                                (rank + file).isEven ? darkSquare : lightSquare,
-                          )
-                        : null,
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: SizedBox.expand(
+        child: Column(
+          children: List.generate(
+            8,
+            (rank) => Expanded(
+              child: Row(
+                children: List.generate(
+                  8,
+                  (file) => Expanded(
+                    child: Container(
+                      width: double.infinity,
+                      height: double.infinity,
+                      color: (rank + file).isEven ? lightSquare : darkSquare,
+                      child: coordinates && (file == 7 || rank == 7)
+                          ? _Coordinate(
+                              rank: rank,
+                              file: file,
+                              orientation: orientation,
+                              color: (rank + file).isEven
+                                  ? darkSquare
+                                  : lightSquare,
+                            )
+                          : null,
+                    ),
                   ),
                 ),
               ),
@@ -79,38 +83,41 @@ class ImageBackground extends Background {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox.expand(
-      child: Stack(
-        children: [
-          Image(image: image),
-          if (coordinates)
-            Column(
-              children: List.generate(
-                8,
-                (rank) => Expanded(
-                  child: Row(
-                    children: List.generate(
-                      8,
-                      (file) => Expanded(
-                        child: SizedBox.expand(
-                          child: rank == 7 || file == 7
-                              ? _Coordinate(
-                                  rank: rank,
-                                  file: file,
-                                  orientation: orientation,
-                                  color: (rank + file).isEven
-                                      ? darkSquare
-                                      : lightSquare,
-                                )
-                              : null,
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: SizedBox.expand(
+        child: Stack(
+          children: [
+            Image(image: image),
+            if (coordinates)
+              Column(
+                children: List.generate(
+                  8,
+                  (rank) => Expanded(
+                    child: Row(
+                      children: List.generate(
+                        8,
+                        (file) => Expanded(
+                          child: SizedBox.expand(
+                            child: rank == 7 || file == 7
+                                ? _Coordinate(
+                                    rank: rank,
+                                    file: file,
+                                    orientation: orientation,
+                                    color: (rank + file).isEven
+                                        ? darkSquare
+                                        : lightSquare,
+                                  )
+                                : null,
+                          ),
                         ),
                       ),
                     ),
                   ),
                 ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chessground
 description: Chess board UI developed for lichess.org. It has no chess logic inside so it can be used for chess variants.
-version: 2.6.3
+version: 2.6.4
 repository: https://github.com/lichess-org/flutter-chessground
 funding:
   - https://lichess.org/patron


### PR DESCRIPTION
Fixes https://github.com/lichess-org/mobile/issues/778 by forcing LTR Directionality for board backgrounds