### PR TITLE
feat: allow scaling arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- Add an optional `scale` parameter to arrows (default is `scale: 1.0`, matching the previous behavior).
+
 ## 3.0.0
 
 Improve board interaction and add support for drawing shapes while playing.

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -405,11 +405,16 @@ class Arrow implements Shape {
   final Color color;
   final SquareId orig;
   final SquareId dest;
+  /// Width of the arrow and size of its tip will be scaled by this factor.
+  ///
+  /// If 1.0, the width will be 1/4th of the square size.
+  final double scale;
 
   const Arrow({
     required this.color,
     required this.orig,
     required this.dest,
+    this.scale = 1.0,
   });
 
   @override

--- a/lib/src/widgets/shape.dart
+++ b/lib/src/widgets/shape.dart
@@ -25,6 +25,7 @@ class ShapeWidget extends StatelessWidget {
         color: final color,
         orig: final orig,
         dest: final dest,
+        scale: final scale,
       ) =>
         SizedBox.square(
           dimension: boardSize,
@@ -34,6 +35,7 @@ class ShapeWidget extends StatelessWidget {
               orientation,
               Coord.fromSquareId(orig),
               Coord.fromSquareId(dest),
+              scale,
             ),
           ),
         ),
@@ -62,17 +64,19 @@ class ShapeWidget extends StatelessWidget {
 }
 
 class _ArrowPainter extends CustomPainter {
-  _ArrowPainter(this.color, this.orientation, this.fromCoord, this.toCoord);
+  _ArrowPainter(
+      this.color, this.orientation, this.fromCoord, this.toCoord, this.scale);
 
   final Color color;
   final Side orientation;
   final Coord fromCoord;
   final Coord toCoord;
+  final double scale;
 
   @override
   void paint(Canvas canvas, Size size) {
     final squareSize = size.width / 8;
-    final lineWidth = squareSize / 4;
+    final lineWidth = scale * squareSize / 4;
     final paint = Paint()
       ..strokeWidth = lineWidth
       ..color = color
@@ -87,7 +91,7 @@ class _ArrowPainter extends CustomPainter {
         math.atan2(toOffset.dy - fromOffset.dy, toOffset.dx - fromOffset.dx);
     final fromMarginOffset =
         Offset(margin * math.cos(angle), margin * math.sin(angle));
-    final arrowSize = squareSize * 0.48;
+    final arrowSize = scale * squareSize * 0.48;
     const arrowAngle = math.pi / 5;
 
     final from = fromOffset + shift + fromMarginOffset;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chessground
 description: Chess board UI developed for lichess.org. It has no chess logic inside so it can be used for chess variants.
-version: 3.0.0
+version: 3.1.0
 repository: https://github.com/lichess-org/flutter-chessground
 funding:
   - https://lichess.org/patron


### PR DESCRIPTION
I'd need this for implementing different arrow sizes in the mobile app, based on the engine evaluation of each move.

This is a really naive approach of course, but it will probably be alright for starters? We might want to apply a different scaling to the arrow body vs its tip in the future (Looks like lichess web UI does that as well).