### PR TITLE
feat!: allow setting pieceAssets and opacity of PieceShape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - `ChessboardEditor` now supports highlighting squares.
 
+### Breaking changes:
+- Added required parameters `piece` and `pieceAssets` to `PieceShape`, removed `role`. Added optional
+  `opacity` parameter.
+
 ## 4.0.0
 
 ### New features:

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -204,20 +204,25 @@ class Arrow implements Shape {
 /// A piece shape that can be drawn on the board.
 @immutable
 class PieceShape implements Shape {
-  final Color color;
-  final Role role;
+  final Color? color;
+  final Piece piece;
   final Square orig;
+  final PieceAssets pieceAssets;
+  final double opacity;
   @override
   final double scale;
 
   /// Creates a new [PieceShape] with the provided values.
   ///
   /// The [scale] must be between 0.0 and 1.0.
+  /// The default [opacity] is 0.5 and the default [scale] is 0.9.
   const PieceShape({
-    required this.color,
-    required this.role,
+    this.color,
+    required this.piece,
     required this.orig,
-    this.scale = 1.0,
+    required this.pieceAssets,
+    this.opacity = 0.5,
+    this.scale = 0.9,
   }) : assert(scale > 0.0 && scale <= 1.0);
 
   @override
@@ -227,7 +232,14 @@ class PieceShape implements Shape {
 
   @override
   Shape withScale(double newScale) {
-    return PieceShape(color: color, role: role, orig: orig, scale: newScale);
+    return PieceShape(
+      color: color,
+      piece: piece,
+      orig: orig,
+      pieceAssets: pieceAssets,
+      opacity: opacity,
+      scale: newScale,
+    );
   }
 
   @override
@@ -236,25 +248,32 @@ class PieceShape implements Shape {
         other is PieceShape &&
             other.runtimeType == runtimeType &&
             other.color == color &&
-            other.role == role &&
+            other.piece == piece &&
             other.orig == orig &&
+            other.pieceAssets == pieceAssets &&
+            other.opacity == opacity &&
             other.scale == scale;
   }
 
   @override
-  int get hashCode => Object.hash(color, role, orig, scale);
+  int get hashCode =>
+      Object.hash(color, opacity, piece, pieceAssets, orig, scale);
 
   /// Creates a copy of this [PieceShape] with the given fields replaced by the new values.
   PieceShape copyWith({
     Color? color,
-    Role? role,
+    Piece? piece,
     Square? orig,
+    PieceAssets? pieceAssets,
+    double? opacity,
     double? scale,
   }) {
     return PieceShape(
       color: color ?? this.color,
-      role: role ?? this.role,
+      piece: piece ?? this.piece,
       orig: orig ?? this.orig,
+      pieceAssets: pieceAssets ?? this.pieceAssets,
+      opacity: opacity ?? this.opacity,
       scale: scale ?? this.scale,
     );
   }

--- a/lib/src/widgets/shape.dart
+++ b/lib/src/widgets/shape.dart
@@ -30,14 +30,14 @@ class ShapeWidget extends StatelessWidget with ChessboardGeometry {
 
   @override
   Widget build(BuildContext context) {
-    return switch (shape) {
-      Arrow(
-        color: final color,
-        orig: final orig,
-        dest: final dest,
-        scale: final scale,
-      ) =>
-        SizedBox.square(
+    switch (shape) {
+      case Arrow(
+          color: final color,
+          orig: final orig,
+          dest: final dest,
+          scale: final scale,
+        ):
+        return SizedBox.square(
           dimension: size,
           child: CustomPaint(
             painter: _ArrowPainter(
@@ -48,9 +48,9 @@ class ShapeWidget extends StatelessWidget with ChessboardGeometry {
               scale,
             ),
           ),
-        ),
-      Circle(color: final color, orig: final orig, scale: final scale) =>
-        SizedBox.square(
+        );
+      case Circle(color: final color, orig: final orig, scale: final scale):
+        return SizedBox.square(
           dimension: size,
           child: CustomPaint(
             painter: _CirclePainter(
@@ -60,26 +60,33 @@ class ShapeWidget extends StatelessWidget with ChessboardGeometry {
               scale,
             ),
           ),
-        ),
-      PieceShape(
-        orig: final orig,
-        role: final role,
-        color: final color,
-        scale: final scale
-      ) =>
-        PositionedSquare(
-          size: size,
-          orientation: orientation,
-          square: orig,
-          child: Image.asset(
-            'assets/piece_sets/mono/${role.uppercaseLetter}.png',
-            package: 'chessground',
-            color: color,
-            width: scale * squareSize,
-            height: scale * squareSize,
-          ),
-        ),
-    };
+        );
+      case PieceShape(
+          color: final color,
+          orig: final orig,
+          piece: final piece,
+          pieceAssets: final pieceAssets,
+          opacity: final opacity,
+          scale: final scale,
+        ):
+        {
+          final asset = pieceAssets[piece.kind]!;
+          return PositionedSquare(
+            size: size,
+            orientation: orientation,
+            square: orig,
+            child: Image.asset(
+              asset.assetName,
+              bundle: asset.bundle,
+              package: asset.package,
+              color: color,
+              opacity: AlwaysStoppedAnimation(opacity),
+              width: scale * squareSize,
+              height: scale * squareSize,
+            ),
+          );
+        }
+    }
   }
 }
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -85,12 +85,16 @@ void main() {
       expect(
         const PieceShape(
           orig: Square.a1,
-          role: Role.knight,
+          piece: Piece.whiteKnight,
+          pieceAssets: PieceSet.horseyAssets,
+          opacity: 0.1,
           color: Color(0xFF000000),
         ),
         const PieceShape(
           orig: Square.a1,
-          role: Role.knight,
+          piece: Piece.whiteKnight,
+          pieceAssets: PieceSet.horseyAssets,
+          opacity: 0.1,
           color: Color(0xFF000000),
         ),
       );
@@ -98,12 +102,16 @@ void main() {
       expect(
         const PieceShape(
           orig: Square.a1,
-          role: Role.knight,
+          piece: Piece.whiteKnight,
+          pieceAssets: PieceSet.horseyAssets,
+          opacity: 0.1,
           color: Color(0xFF000000),
         ).hashCode,
         const PieceShape(
           orig: Square.a1,
-          role: Role.knight,
+          piece: Piece.whiteKnight,
+          pieceAssets: PieceSet.horseyAssets,
+          opacity: 0.1,
           color: Color(0xFF000000),
         ).hashCode,
       );
@@ -111,15 +119,17 @@ void main() {
       expect(
         const PieceShape(
           orig: Square.a1,
-          role: Role.knight,
+          piece: Piece.whiteKnight,
+          pieceAssets: PieceSet.horseyAssets,
           color: Color(0xFF000000),
         ),
         isNot(
           const PieceShape(
             orig: Square.a1,
-            role: Role.knight,
+            piece: Piece.whiteKnight,
+            pieceAssets: PieceSet.horseyAssets,
             color: Color(0xFF000000),
-            scale: 0.9,
+            scale: 0.123,
           ),
         ),
       );
@@ -212,19 +222,22 @@ void main() {
 
       const pieceShape = PieceShape(
         orig: Square.a1,
-        role: Role.knight,
+        piece: Piece.whiteKnight,
+        pieceAssets: PieceSet.horseyAssets,
         color: Color(0xFF000000),
       );
 
       expect(
         pieceShape.copyWith(
           orig: Square.a2,
-          role: Role.bishop,
+          opacity: 0.123,
           color: const Color(0xFF000001),
         ),
         const PieceShape(
           orig: Square.a2,
-          role: Role.bishop,
+          piece: Piece.whiteKnight,
+          pieceAssets: PieceSet.horseyAssets,
+          opacity: 0.123,
           color: Color(0xFF000001),
         ),
       );

--- a/test/widgets/board_test.dart
+++ b/test/widgets/board_test.dart
@@ -808,8 +808,8 @@ void main() {
           initialShapes: ISet({
             const PieceShape(
               orig: Square.e4,
-              role: Role.pawn,
-              color: Color(0xFF0000FF),
+              piece: Piece.whitePawn,
+              pieceAssets: PieceSet.horseyAssets,
             ),
           }),
         ),


### PR DESCRIPTION
As discussed on Discord, this is needed to display promotions in analysis board consistently with lichess.org and the old lichess app.