### PR TITLE
fix promotion selection if player on top promotes

### DIFF
--- a/lib/src/widgets/promotion.dart
+++ b/lib/src/widgets/promotion.dart
@@ -52,14 +52,30 @@ class PromotionSelector extends StatelessWidget with ChessboardGeometry {
 
   @override
   Widget build(BuildContext context) {
+    final isPromotionSquareAtTop =
+        orientation == Side.white && square.rank == Rank.eighth ||
+        orientation == Side.black && square.rank == Rank.first;
     final anchorSquare =
-        (orientation == Side.white && square.rank == Rank.eighth ||
-                orientation == Side.black && square.rank == Rank.first)
+        isPromotionSquareAtTop
             ? square
             : Square.fromCoords(
               square.file,
               orientation == Side.white ? Rank.fourth : Rank.fifth,
             );
+    final pieces =
+        isPromotionSquareAtTop
+            ? [
+              Piece(color: color, role: Role.queen, promoted: true),
+              Piece(color: color, role: Role.knight, promoted: true),
+              Piece(color: color, role: Role.rook, promoted: true),
+              Piece(color: color, role: Role.bishop, promoted: true),
+            ]
+            : [
+              Piece(color: color, role: Role.bishop, promoted: true),
+              Piece(color: color, role: Role.rook, promoted: true),
+              Piece(color: color, role: Role.knight, promoted: true),
+              Piece(color: color, role: Role.queen, promoted: true),
+            ];
 
     final offset = squareOffset(anchorSquare);
 
@@ -78,12 +94,7 @@ class PromotionSelector extends StatelessWidget with ChessboardGeometry {
               left: offset.dx,
               top: offset.dy,
               child: Column(
-                children: [
-                      Piece(color: color, role: Role.queen, promoted: true),
-                      Piece(color: color, role: Role.knight, promoted: true),
-                      Piece(color: color, role: Role.rook, promoted: true),
-                      Piece(color: color, role: Role.bishop, promoted: true),
-                    ]
+                children: pieces
                     .map((Piece piece) {
                       return GestureDetector(
                         onTap: () => onSelect(piece.role),

--- a/test/widgets/board_test.dart
+++ b/test/widgets/board_test.dart
@@ -832,6 +832,32 @@ void main() {
       expect(find.byKey(const Key('f8-whiteknight')), findsOneWidget);
       expect(find.byKey(const Key('f7-whitepawn')), findsNothing);
     });
+    testWidgets('Player on top promotes a bishop', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const _TestApp(
+          initialPlayerSide: PlayerSide.both,
+          initialFen: 'K7/8/k7/8/8/8/p7/1Q4n1 b - - 0 1',
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('a2-blackpawn')));
+      await tester.pump();
+      await tester.tapAt(squareOffset(tester, Square.b1));
+      await tester.pump();
+
+      // wait for promotion selector to show
+      await tester.pump();
+      expect(find.byType(PromotionSelector), findsOneWidget);
+
+      // promotion pawn is not visible
+      expect(find.byKey(const Key('a2-blackpawn')), findsNothing);
+
+      // tap on the bishop
+      await tester.tapAt(squareOffset(tester, Square.b4));
+      await tester.pump();
+      expect(find.byKey(const Key('b1-blackbishop')), findsOneWidget);
+      expect(find.byKey(const Key('a2-blackpawn')), findsNothing);
+    });
 
     testWidgets('cancels promotion', (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
fixes https://github.com/lichess-org/mobile/issues/1286
Now the other of material is correct (queen on promotion square) even when the player on top promotes.
<img width="594" height="1341" alt="grafik" src="https://github.com/user-attachments/assets/2bf7c5f8-c12c-487a-a27d-b64a935170f6" />

Also adds a test case that fails without the changes and passes with them.


