### PR TITLE
add `validDropSquares` to GameData to fix invalid drop moves in crazyhouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 8.3.0
+
+- Add `validDropSquares` to `GameData`. For drop moves, `Chessboard` will now only call `onMove` 
+  if and only if `validDropSquares` contains the target square.
+  This makes the behavior consistent with normal moves.
+  Note that dropping a pawn on the back rank does not trigger `onMove`, even if `validDropSquares` would allow it.
+
 ## 8.2.1
 
 - Fix top player promotion selector when `canPromoteToKing` is true.

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -29,6 +29,7 @@ class GameData {
     required this.playerSide,
     required this.sideToMove,
     required this.validMoves,
+    this.validDropSquares = const ISet.empty(),
     required this.promotionMove,
     required this.onMove,
     required this.onPromotionSelection,
@@ -53,6 +54,9 @@ class GameData {
 
   /// Set of moves allowed to be played by current side to move.
   final ValidMoves validMoves;
+
+  /// Set of squares where the current side to move can drop a piece in variants such as Crazyhouse.
+  final ValidDropSquares validDropSquares;
 
   /// Callback called after a move has been made.
   ///
@@ -99,6 +103,9 @@ typedef Pieces = Map<Square, Piece>;
 
 /// Sets of each valid destinations for an origin square.
 typedef ValidMoves = IMap<Square, ISet<Square>>;
+
+/// Set of squares where a piece can be dropped in variants such as Crazyhouse.
+typedef ValidDropSquares = ISet<Square>;
 
 /// Square highlight color or image on the chessboard.
 @immutable

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -437,7 +437,7 @@ class _BoardState extends State<Chessboard> {
                 if (backRankPawnDrop) return;
 
                 final move = DropMove(to: square, role: details.data.role);
-                if (game.sideToMove == piece.color && !pieces.containsKey(square)) {
+                if (game.sideToMove == piece.color && game.validDropSquares.contains(square)) {
                   game.onMove(move, viaDragAndDrop: true);
                   _lastDrop = move;
                 } else if (game.premovable != null) {

--- a/test/widgets/board_test.dart
+++ b/test/widgets/board_test.dart
@@ -409,6 +409,8 @@ void main() {
       await tester.pumpWidget(
         _TestApp(
           initialPlayerSide: PlayerSide.both,
+          rule: Rule.crazyhouse,
+          initialFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Pn] w KQkq - 0 1',
           settings: const ChessboardSettings(enableDropMoves: true),
           bottomWidget: Column(
             children: [
@@ -466,7 +468,7 @@ void main() {
       await tester.pumpWidget(
         _TestApp(
           initialPlayerSide: PlayerSide.both,
-          initialFen: '8/7K/8/8/8/8/7k/8[PN] w - - 0 1',
+          initialFen: '8/8/3K4/8/3k4/8/8/8[PNp] w - - 0 1',
           rule: Rule.crazyhouse,
           settings: const ChessboardSettings(enableDropMoves: true),
           bottomWidget: Column(
@@ -523,6 +525,54 @@ void main() {
 
       await tester.pumpAndSettle();
       expect(find.byKey(const Key('a8-whiteknight')), findsOneWidget);
+    });
+
+    testWidgets('Cannot play illegal drop moves', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _TestApp(
+          initialPlayerSide: PlayerSide.both,
+          // white is in check, so we can't drag the pawn onto a square that doesn't block the check.
+          initialFen: 'rnb1kbnr/pppp2pp/8/4p3/8/2q2N2/PP2PPPP/1R2KB1R[P] w - - 8 8',
+          rule: Rule.crazyhouse,
+          settings: const ChessboardSettings(enableDropMoves: true),
+          bottomWidget: Column(
+            children: [
+              Draggable(
+                key: const Key('whitePawn'),
+                data: Piece.whitePawn,
+                feedback: const SizedBox.shrink(),
+                child: PieceWidget(
+                  piece: Piece.whitePawn,
+                  size: squareSize,
+                  pieceAssets: PieceSet.merida.assets,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final whitePawnDraggable = find.byKey(const Key('whitePawn'));
+
+      // This square is empty, but this move wouldn't block the check, so it should not be allowed
+      await tester.drag(
+        whitePawnDraggable,
+        tester.getCenter(find.byKey(const Key('a4-drag-target'))) -
+            tester.getCenter(whitePawnDraggable),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('a4-whitepawn')), findsNothing);
+
+      // Only square that blocks the check
+      await tester.drag(
+        whitePawnDraggable,
+        tester.getCenter(find.byKey(const Key('d2-drag-target'))) -
+            tester.getCenter(whitePawnDraggable),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('d2-whitepawn')), findsOneWidget);
     });
 
     testWidgets('no drag targets if drop moves not explicitly enabled', (
@@ -2332,6 +2382,7 @@ class _TestAppState extends State<_TestApp> {
                 isCheck: position.isCheck,
                 sideToMove: position.turn == Side.white ? Side.white : Side.black,
                 validMoves: makeLegalMoves(position),
+                validDropSquares: position.legalDrops.squares.toISet(),
                 promotionMove: promotionMove,
                 onMove: _onMove,
                 onPromotionSelection: (Role? role) {


### PR DESCRIPTION
Currently, the board considers any drop onto an open sqaure valid (excluding pawn drops onto the back rank).

However, when in check this breaks down, leading to `onMove` being called for invalid drops, which is consistent with the behavior for normal moves (and causes crashes in lichess mobile currently).

To fix this, introduce `GameData.validDropSquares`.