### PR TITLE
Add a new "move on release" board setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
-## 10.2.0
+## 10.1.0
 
+- Add Totoy piece set.
 - Add `ChessboardSettings.moveOnRelease`: when enabled, a tap-to-move is
   committed on pointer release instead of pointer press, and a square target
   follows the finger so the destination can be adjusted before releasing.
 
-## 10.1.0
-
-- Add Totoy piece set.
 
 ## 10.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 10.2.0
+
+- Add `ChessboardSettings.moveOnRelease`: when enabled, a tap-to-move is
+  committed on pointer release instead of pointer press, and a square target
+  follows the finger so the destination can be adjusted before releasing.
+
 ## 10.1.0
 
 - Add Totoy piece set.

--- a/example/lib/atomic_game_page.dart
+++ b/example/lib/atomic_game_page.dart
@@ -114,7 +114,8 @@ class _AtomicGamePageState extends State<AtomicGamePage> {
   void _newGame() {
     position = Atomic.initial;
     lastMove = null;
-    _controller.updatePosition(_buildGame(), animate: false, resetPremove: true);
+    _controller.updatePosition(_buildGame(),
+        animate: false, resetPremove: true);
     setState(() {});
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -80,6 +80,7 @@ class _HomePageState extends State<HomePage> {
   late final ValueNotifier<bool> _canUndo;
   late final ValueNotifier<Position> _positionNotifier;
   PieceShiftMethod pieceShiftMethod = PieceShiftMethod.either;
+  bool moveOnRelease = false;
   DragTargetKind dragTargetKind = DragTargetKind.circle;
   BoardTheme boardTheme = BoardTheme.brown;
   bool drawMode = true;
@@ -112,7 +113,8 @@ class _HomePageState extends State<HomePage> {
         lastMove = null;
         _canUndo.value = false;
         _positionNotifier.value = position;
-        _controller.updatePosition(_buildGame(), animate: false, resetPremove: true);
+        _controller.updatePosition(_buildGame(),
+            animate: false, resetPremove: true);
       },
     );
 
@@ -137,7 +139,8 @@ class _HomePageState extends State<HomePage> {
                           lastMove = null;
                           _canUndo.value = false;
                           _positionNotifier.value = position;
-                          _controller.updatePosition(_buildGame(), animate: false, resetPremove: true);
+                          _controller.updatePosition(_buildGame(),
+                              animate: false, resetPremove: true);
                         }
                       : null,
                 ),
@@ -262,6 +265,15 @@ class _HomePageState extends State<HomePage> {
                   ),
                 ),
                 SettingsButton(
+                  label: 'Move on release',
+                  value: moveOnRelease ? 'ON' : 'OFF',
+                  onPressed: () {
+                    setState(() {
+                      moveOnRelease = !moveOnRelease;
+                    });
+                  },
+                ),
+                SettingsButton(
                   label: 'Test Crazyhouse drop moves',
                   value: testDropMoves ? 'ON' : 'OFF',
                   onPressed: () {
@@ -271,7 +283,8 @@ class _HomePageState extends State<HomePage> {
                     lastMove = null;
                     _canUndo.value = false;
                     _positionNotifier.value = position;
-                    _controller.updatePosition(_buildGame(), animate: false, resetPremove: true);
+                    _controller.updatePosition(_buildGame(),
+                        animate: false, resetPremove: true);
                     setState(() {}); // Show/hide CrazyhouseMenu.
                   },
                 ),
@@ -311,6 +324,7 @@ class _HomePageState extends State<HomePage> {
       drawShape: DrawShapeOptions(enable: drawMode),
       enableDrops: testDropMoves,
       pieceShiftMethod: pieceShiftMethod,
+      moveOnRelease: moveOnRelease,
       autoQueenPromotionOnPremove: false,
       pieceOrientationBehavior: playMode == Mode.freePlay
           ? PieceOrientationBehavior.opponentUpsideDown

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "10.0.3"
+    version: "10.1.0"
   clock:
     dependency: transitive
     description:

--- a/lib/src/board_settings.dart
+++ b/lib/src/board_settings.dart
@@ -108,6 +108,7 @@ class ChessboardSettings {
     this.autoQueenPromotion = false,
     this.autoQueenPromotionOnPremove = true,
     this.pieceShiftMethod = PieceShiftMethod.either,
+    this.moveOnRelease = false,
     this.canPromoteToKing = false,
   });
 
@@ -184,6 +185,19 @@ class ChessboardSettings {
   /// Controls how moves are made.
   final PieceShiftMethod pieceShiftMethod;
 
+  /// Whether a tap-to-move (selecting a piece, then a destination) is triggered
+  /// when the pointer is released rather than when it is pressed.
+  ///
+  /// By default (`false`) the move is made as soon as the destination square is
+  /// touched. When set to `true`, after a piece has been selected, touching a
+  /// square only arms the move: the user can slide their finger to change the
+  /// destination, and the move is committed on the square where the pointer is
+  /// released. A square target follows the finger while choosing, like when
+  /// dragging a piece but without the piece, and uses [dragTargetKind].
+  ///
+  /// This has no effect on drag-and-drop, which always commits on release.
+  final bool moveOnRelease;
+
   /// Whether the pawn can be promoted to a king (for example in Antichess).
   final bool canPromoteToKing;
 
@@ -224,6 +238,7 @@ class ChessboardSettings {
         other.autoQueenPromotion == autoQueenPromotion &&
         other.autoQueenPromotionOnPremove == autoQueenPromotionOnPremove &&
         other.pieceShiftMethod == pieceShiftMethod &&
+        other.moveOnRelease == moveOnRelease &&
         other.canPromoteToKing == canPromoteToKing &&
         other.drawShape == drawShape;
   }
@@ -252,6 +267,7 @@ class ChessboardSettings {
     autoQueenPromotion,
     autoQueenPromotionOnPremove,
     pieceShiftMethod,
+    moveOnRelease,
     canPromoteToKing,
     drawShape,
   ]);
@@ -279,6 +295,7 @@ class ChessboardSettings {
     bool? autoQueenPromotion,
     bool? autoQueenPromotionOnPremove,
     PieceShiftMethod? pieceShiftMethod,
+    bool? moveOnRelease,
     bool? canPromoteToKing,
     DrawShapeOptions? drawShape,
   }) {
@@ -305,6 +322,7 @@ class ChessboardSettings {
       autoQueenPromotionOnPremove: autoQueenPromotionOnPremove ?? this.autoQueenPromotionOnPremove,
       autoQueenPromotion: autoQueenPromotion ?? this.autoQueenPromotion,
       pieceShiftMethod: pieceShiftMethod ?? this.pieceShiftMethod,
+      moveOnRelease: moveOnRelease ?? this.moveOnRelease,
       canPromoteToKing: canPromoteToKing ?? this.canPromoteToKing,
       drawShape: drawShape ?? this.drawShape,
     );

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -129,6 +129,12 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
   /// Avatar for the piece that is currently being dragged.
   _DragAvatar? _dragAvatar;
 
+  /// Target follower shown while a tap-to-move destination is being chosen with
+  /// the pointer still down, when [ChessboardSettings.moveOnRelease] is enabled.
+  ///
+  /// When non-null, the move is deferred until the pointer is released.
+  _DragAvatar? _releaseMoveTarget;
+
   /// Once a piece is dragged, holds the square id of the piece.
   late final ValueNotifier<Square?> _draggedPieceSquareNotifier;
 
@@ -485,6 +491,7 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
     _explosionNotifier.dispose();
     _draggedPieceSquareNotifier.dispose();
     _dragAvatar?.cancel();
+    _releaseMoveTarget?.cancel();
     _cancelShapesDoubleTapTimer?.cancel();
     super.dispose();
   }
@@ -502,6 +509,8 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
       _currentPointerDownEvent = null;
       _dragAvatar?.cancel();
       _dragAvatar = null;
+      _releaseMoveTarget?.cancel();
+      _releaseMoveTarget = null;
       _draggedPieceSquareNotifier.value = null;
       selected = null;
       _premoveDests = null;
@@ -679,11 +688,12 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
     // - if the move was not possible but there is a movable piece under the
     // target square, select it
     if (selected != null && square != selected) {
-      final couldMove = _tryMoveOrPremoveTo(square);
-      if (!couldMove && _isMovable(piece)) {
-        _setSelection(square);
+      // When moveOnRelease is enabled, don't move yet: arm the move and show a
+      // target following the finger. The move is committed on pointer up.
+      if (widget.settings.moveOnRelease) {
+        _beginReleaseMove(details);
       } else {
-        _setSelection(null);
+        _moveSelectedOrSelect(square);
       }
     }
     // the selected piece is touched again:
@@ -746,6 +756,24 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
       }
     }
 
+    // While a moveOnRelease destination is being chosen, the square target
+    // follows the finger; the move is committed on pointer up.
+    if (_releaseMoveTarget != null) {
+      if (_currentPointerDownEvent != null &&
+          _currentPointerDownEvent!.pointer == details.pointer) {
+        final bool isMousePointer = details.kind == PointerDeviceKind.mouse;
+        _releaseMoveTarget!.updateSquareTarget(
+          _squareTargetGlobalOffset(
+            details.localPosition,
+            _renderBox!,
+            isLargeCircle:
+                !isMousePointer && widget.settings.dragTargetKind == DragTargetKind.circle,
+          ),
+        );
+      }
+      return;
+    }
+
     if (_currentPointerDownEvent == null ||
         _currentPointerDownEvent!.pointer != details.pointer ||
         widget.settings.pieceShiftMethod == PieceShiftMethod.tapTwoSquares) {
@@ -790,6 +818,21 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
     }
 
     final square = widget.offsetSquare(details.localPosition);
+
+    // handle pointer up while choosing a moveOnRelease destination: commit the
+    // move on the square under the released pointer
+    if (_releaseMoveTarget != null) {
+      _endReleaseMoveTarget();
+      if (square != null && square != selected) {
+        _moveSelectedOrSelect(square);
+      } else {
+        _setSelection(null);
+      }
+      _shouldDeselectOnTapUp = false;
+      _shouldCancelPremoveOnTapUp = false;
+      _currentPointerDownEvent = null;
+      return;
+    }
 
     // handle pointer up while dragging a piece
     if (_dragAvatar != null) {
@@ -856,6 +899,7 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
     }
 
     _onDragEnd();
+    _endReleaseMoveTarget();
     _draggedPieceSquareNotifier.value = null;
     _currentPointerDownEvent = null;
     _shouldCancelPremoveOnTapUp = false;
@@ -916,10 +960,57 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
     _renderBox = null;
   }
 
+  /// Tries to move the selected piece to [square]; if that is not possible but a
+  /// movable piece sits on [square], selects it instead; otherwise clears the
+  /// selection.
+  void _moveSelectedOrSelect(Square square) {
+    final couldMove = _tryMoveOrPremoveTo(square);
+    if (!couldMove && _isMovable(pieces[square])) {
+      _setSelection(square);
+    } else {
+      _setSelection(null);
+    }
+  }
+
+  /// Starts following the pointer with a square target so the user can choose a
+  /// move destination, committed on pointer up (see [ChessboardSettings.moveOnRelease]).
+  void _beginReleaseMove(PointerDownEvent origin) {
+    _renderBox ??= context.findRenderObject()! as RenderBox;
+    final bool isMousePointer = origin.kind == PointerDeviceKind.mouse;
+    final targetKind =
+        isMousePointer && widget.settings.dragTargetKind != DragTargetKind.none
+            ? DragTargetKind.square
+            : widget.settings.dragTargetKind;
+    _releaseMoveTarget = _DragAvatar(
+      overlayState: Overlay.of(context, debugRequiredFor: widget),
+      initialPosition: origin.position,
+      initialTargetPosition: _squareTargetGlobalOffset(
+        origin.localPosition,
+        _renderBox!,
+        isLargeCircle: targetKind == DragTargetKind.circle,
+      ),
+      // No piece is shown, only the square target following the finger.
+      image: null,
+      feedbackSize: widget.squareSize,
+      feedbackOffset: Offset.zero,
+      upsideDown: false,
+      targetKind: targetKind,
+      squareSize: widget.squareSize,
+    );
+  }
+
+  void _endReleaseMoveTarget() {
+    _releaseMoveTarget?.end();
+    _releaseMoveTarget = null;
+    _renderBox = null;
+  }
+
   /// Cancels the current gesture and stops current selection/drag.
   void _cancelGesture() {
     _dragAvatar?.end();
     _dragAvatar = null;
+    _releaseMoveTarget?.end();
+    _releaseMoveTarget = null;
     _renderBox = null;
     _setSelection(null);
     _draggedPieceSquareNotifier.value = null;

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -989,7 +989,6 @@ class _BoardState extends State<Chessboard> with TickerProviderStateMixin {
         _renderBox!,
         isLargeCircle: targetKind == DragTargetKind.circle,
       ),
-      // No piece is shown, only the square target following the finger.
       image: null,
       feedbackSize: widget.squareSize,
       feedbackOffset: Offset.zero,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chessground
 description: Chess board UI developed for lichess.org. It has no chess logic inside so it can be used for chess variants.
-version: 10.0.3
+version: 10.1.0
 repository: https://github.com/lichess-org/flutter-chessground
 funding:
   - https://lichess.org/patron

--- a/test/widgets/board_test.dart
+++ b/test/widgets/board_test.dart
@@ -75,6 +75,16 @@ FadingPiecesPainter? _fadingPiecesPainter(WidgetTester tester) {
   return null;
 }
 
+DragSquareTargetPainter? _dragSquareTargetPainter(WidgetTester tester) {
+  for (final element in find.byType(CustomPaint).evaluate()) {
+    final widget = element.widget as CustomPaint;
+    if (widget.painter is DragSquareTargetPainter) {
+      return widget.painter! as DragSquareTargetPainter;
+    }
+  }
+  return null;
+}
+
 bool _isSelectedHighlight(WidgetTester tester, Square square) {
   return _highlightsPainter(tester).interactionNotifier.selected == square;
 }
@@ -885,6 +895,131 @@ void main() {
       () => onTouchedSquare(Square.e3),
     ]);
     verifyNoMoreInteractions(onTouchedSquare);
+  });
+
+  group('moveOnRelease', () {
+    const settings = ChessboardSettings(animationDuration: Duration.zero, moveOnRelease: true);
+
+    testWidgets('move is committed on pointer up, not on pointer down', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const _TestApp(settings: settings, initialPlayerSide: PlayerSide.white),
+      );
+
+      // Select the pawn.
+      await tester.tapAt(squareOffset(tester, Square.e2));
+      await tester.pump();
+      expect(_isSelectedHighlight(tester, Square.e2), isTrue);
+
+      await TestAsyncUtils.guard<void>(() async {
+        // Press on the destination square: the move must NOT be made yet.
+        final gesture = await tester.startGesture(squareOffset(tester, Square.e4));
+        await tester.pump();
+        expect(_piecesPainter(tester).pieces.containsKey(Square.e4), isFalse);
+        expect(_piecesPainter(tester).pieces[Square.e2], Piece.whitePawn);
+
+        // Releasing commits the move.
+        await gesture.up();
+        await tester.pump();
+      });
+
+      expect(_piecesPainter(tester).pieces[Square.e4], Piece.whitePawn);
+      expect(_piecesPainter(tester).pieces.containsKey(Square.e2), isFalse);
+      expect(_isLastMoveHighlight(tester, Square.e2), isTrue);
+      expect(_isLastMoveHighlight(tester, Square.e4), isTrue);
+    });
+
+    testWidgets('sliding the finger changes the destination before release', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const _TestApp(settings: settings, initialPlayerSide: PlayerSide.white),
+      );
+
+      // Select the pawn.
+      await tester.tapAt(squareOffset(tester, Square.e2));
+      await tester.pump();
+
+      await TestAsyncUtils.guard<void>(() async {
+        // Press on e3, then slide to e4 and release there.
+        final gesture = await tester.startGesture(squareOffset(tester, Square.e3));
+        await tester.pump();
+        await gesture.moveTo(squareOffset(tester, Square.e4));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+      });
+
+      // The move lands on the square under the released pointer (e4), not e3.
+      expect(_piecesPainter(tester).pieces[Square.e4], Piece.whitePawn);
+      expect(_piecesPainter(tester).pieces.containsKey(Square.e3), isFalse);
+      expect(_piecesPainter(tester).pieces.containsKey(Square.e2), isFalse);
+    });
+
+    testWidgets('square target follows the finger before release', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const _TestApp(settings: settings, initialPlayerSide: PlayerSide.white),
+      );
+
+      // Select the pawn.
+      await tester.tapAt(squareOffset(tester, Square.e2));
+      await tester.pump();
+
+      await TestAsyncUtils.guard<void>(() async {
+        // No target is shown before a destination is pressed.
+        expect(_dragSquareTargetPainter(tester), isNull);
+
+        // Press on e3: a square target appears.
+        final gesture = await tester.startGesture(squareOffset(tester, Square.e3));
+        await tester.pump();
+        final posOnE3 = _dragSquareTargetPainter(tester)?.positionNotifier.value;
+        expect(posOnE3, isNotNull);
+
+        // Slide up one rank to e4: the target tracks the finger by one square.
+        await gesture.moveTo(squareOffset(tester, Square.e4));
+        await tester.pump();
+        final posOnE4 = _dragSquareTargetPainter(tester)?.positionNotifier.value;
+        expect(posOnE4, isNotNull);
+        expect(posOnE4! - posOnE3!, const Offset(0, -squareSize));
+
+        // Slide right one file to f4: the target tracks the finger horizontally.
+        await gesture.moveTo(squareOffset(tester, Square.f4));
+        await tester.pump();
+        final posOnF4 = _dragSquareTargetPainter(tester)?.positionNotifier.value;
+        expect(posOnF4, isNotNull);
+        expect(posOnF4! - posOnE4, const Offset(squareSize, 0));
+
+        await gesture.up();
+        await tester.pump();
+      });
+
+      // The target is removed once the pointer is released.
+      expect(_dragSquareTargetPainter(tester), isNull);
+    });
+
+    testWidgets('releasing on an invalid square keeps the piece in place', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const _TestApp(settings: settings, initialPlayerSide: PlayerSide.white),
+      );
+
+      await tester.tapAt(squareOffset(tester, Square.e2));
+      await tester.pump();
+
+      await TestAsyncUtils.guard<void>(() async {
+        // e5 is not a legal destination for the e2 pawn.
+        final gesture = await tester.startGesture(squareOffset(tester, Square.e5));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+      });
+
+      expect(_piecesPainter(tester).pieces[Square.e2], Piece.whitePawn);
+      expect(_piecesPainter(tester).pieces.containsKey(Square.e5), isFalse);
+      expect(_isSelectedHighlight(tester, Square.e2), isFalse);
+    });
   });
 
   group('Drop squares enabled', () {


### PR DESCRIPTION
Add `ChessboardSettings.moveOnRelease`: when enabled, a tap-to-move is committed on pointer release instead of pointer press, and a square target follows the finger so the destination can be adjusted before releasing.

Closes #93